### PR TITLE
authentication tests, submit precondition tests, auth modifier

### DIFF
--- a/contracts/Receiver.sol
+++ b/contracts/Receiver.sol
@@ -99,9 +99,6 @@ contract BasicReceiver {
     uint8 v, bytes32 r, bytes32 s
   ) public
   {
-    // verify signer key is live for this signer/ttl
-    require(block.timestamp < ttl, 'receiver-submit-msg-ttl');
-
     bytes32 sighash = digest(tag, seq, sec, ttl, val);
     address signer = ecrecover(sighash, v, r, s);
 


### PR DESCRIPTION
Added some simple tests for submit precondition (e.g. timestamp > signer ttl) and authentication (owner == msg.sender)
Added an auth modifier to replace require(owner == msg.sender)
Remove a redundant require in submit