### PR TITLE
fix: broken tests

### DIFF
--- a/test/medianizer-test.ts
+++ b/test/medianizer-test.ts
@@ -1,6 +1,5 @@
 import * as hh from 'hardhat'
 import { ethers } from 'hardhat'
-import { Contract } from 'hardhat/types'
 import { fail, revert, snapshot, want } from 'minihat'
 
 const debug = require('debug')('feedbase:test')

--- a/test/sensor-test.ts
+++ b/test/sensor-test.ts
@@ -9,13 +9,13 @@ import { want, send, fail, snapshot, revert, U256_MAX } from 'minihat'
 const debug = require('debug')('feedbase:sensor')
 
 describe('receiver BasicReceiver BasicReceiverFactory', ()=>{
-  let signers : ethers.Wallet;
+  let signers : [any, any];
   let ali, bob;
   let ALI, BOB;
   let fb, fb_type;
   let rec, rec_type;
   let recfab, recfab_type;
-  let opts = { receiver:undefined, chainId:undefined, signer:undefined};
+  let opts = { receiver:undefined, chainId:undefined, signer:undefined, tag:undefined, interval:undefined };
 
   let tag, seq, sec, ttl, val;
   let chainId;
@@ -69,4 +69,3 @@ describe('receiver BasicReceiver BasicReceiverFactory', ()=>{
 
   })
 });
-


### PR DESCRIPTION
Some minor cleanup to get tests running (there are some errors running `npx hardhat test` on `master` branch):

```
feedbase git:master
λ npx hardhat test
WARN using delayed time
An unexpected error occurred:

test/medianizer-test.ts(3,10): error TS2305: Module '"hardhat/types"' has no exported member 'Contract'.
```

There are no tests in `sensor-test.ts` so there's nothing to run (just setup) but trying manually:
```
feedbase git:master
λ npx hardhat test test/sensor-test.ts
An unexpected error occurred:

test/sensor-test.ts(12,17): error TS2503: Cannot find namespace 'ethers'.
test/sensor-test.ts(62,12): error TS2339: Property 'interval' does not exist on type '{ receiver: any; chainId: any; signer: any; }'.
test/sensor-test.ts(63,12): error TS2339: Property 'tag' does not exist on type '{ receiver: any; chainId: any; signer: any; }'.
```