### PR TITLE
Modify receiver tests for new sec use

### DIFF
--- a/scripts/message.ts
+++ b/scripts/message.ts
@@ -18,7 +18,7 @@ export function makeUpdateDigest(obj: any): Buffer {
       ],
       Submit: [
         { name: 'tag', type: 'bytes32' },
-        { name: 'seq', type: 'uint256' },
+        { name: 'sec', type: 'uint256' },
         { name: 'ttl', type: 'uint256' },
         { name: 'val', type: 'bytes32' }
       ]
@@ -32,7 +32,7 @@ export function makeUpdateDigest(obj: any): Buffer {
     },
     message: {
       tag: obj.tag,
-      seq: obj.seq,
+      sec: obj.sec,
       ttl: obj.ttl,
       val: obj.val
     }

--- a/src/Receiver.sol
+++ b/src/Receiver.sol
@@ -94,7 +94,7 @@ contract BasicReceiver {
         require(isSigner[signer], 'receiver-submit-bad-signer');
         require(block.timestamp <  ttl, 'receiver-submit-ttl');
         require(block.timestamp >= sec, 'receiver-submit-sec');
-        require(seq > prevTime[tag], 'receiver-submit-seq');
+        require(sec > prevTime[tag], 'receiver-submit-seq');
         prevTime[tag] = sec;
 
         emit Submit(msg.sender, signer, tag, sec, ttl, val);


### PR DESCRIPTION
All tests passing locally. Modified for new logic and added test against future leaking.
`sec` error message for future leaking and `seq` error message for non-increasing sec sequence.

```
/feedbase $> npm run test

> feedbase@0.3.0 pretest
> npm run build


> feedbase@0.3.0 build
> npm run build:ts && npm run build:sol


> feedbase@0.3.0 build:ts
> npx tsc -b


> feedbase@0.3.0 build:sol
> npx hardhat compile

Solidity 0.8.15 is not fully supported yet. You can still use Hardhat, but some features, like stack traces, might not work correctly.

Learn more at https://hardhat.org/hardhat-runner/docs/reference/solidity-support

(node:94929) ExperimentalWarning: stream/web is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Nothing to compile

> feedbase@0.3.0 test
> ts-mocha test/*.ts test/**/*.ts

WARN using delayed time
WARN using delayed time


  feedbase
    ✔ ttl on pull
    ✔ pull successive (53ms)
    ✔ Push event

  feedbase format utils
    ✔ bytes32

  medianizer
    poke
      ✔ stale src feed (114ms)
      ✔ One value
      ✔ Two values (45ms)
      ✔ Three values (63ms)
      ✔ Four values (40ms)
      ✔ Five values (51ms)
      ✔ Two unordered values
      ✔ Three unordered values
      ✔ Four unordered values (43ms)
      ✔ Five unordered values (50ms)

  receiver BasicReceiver BasicReceiverFactory
    ✔ auth (84ms)
    submit preconditions
      ✔ ttl
      ✔ bad-signer unset
    eip712 submit
      ✔ pass submit
      ✔ sec must increase from last tag time / setCost deposit request submit


  19 passing (963ms)```