### PR TITLE
failing test showing poking will increase time taken for result to re…

### DIFF
--- a/test/twap-test.ts
+++ b/test/twap-test.ts
@@ -314,23 +314,23 @@ describe('twap', () => {
         })
 
         it('frequent pokes', async () => {
-            let price = BigNumber.from(1000)
+            let price = ray(1000)
             let range = 1000
-            let granularity = 5;
+            let granularity = 10;
             await send(twap.setConfig, tag, [ALI, tag, BigNumber.from(range), ttl]);
             await send(fb.push, tag, b32(price), constants.MaxUint256)
             await send(twap.poke, tag)
             await mine(hh, range)
             await send(twap.poke, tag)
 
-            await send(fb.push, tag, constants.HashZero, constants.MaxUint256)
+            await send(fb.push, tag, b32(price.mul(2)), constants.MaxUint256)
             let time = range / granularity
             for (let i = 0; i < 100000000; i += 1) {
                 await mine(hh, time - 1)
                 await send(twap.poke, tag)
                 let [val,] = await fb.pull(twap.address, tag)
                 console.log(i * time, val)
-                if (BigNumber.from(val).lt(price.div(100))) break;
+                if (BigNumber.from(val).gt(price.mul(199).div(100))) break;
             }
         })
     })


### PR DESCRIPTION
…ach feed price

This PR is a discussion to check if this is desired behaviour. Delete if it is. I would expect a twap to linearly move between two price points as it becomes aware of them, independently of how it's poked along the way. But frequent pokes cause it to approach feed price asymptotically, without pokes it moves linearly. Is this a bug or acceptable behaviour to save gas